### PR TITLE
feat(cargo-codspeed): add `--features vendored-openssl`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
       #   if: ${{ matrix.setup }}
       #   run: ${{ matrix.setup }}
 
-      - run: cargo build --release --bin cargo-codspeed --target ${{ matrix.target }}
+      - run: cargo build --release --features vendored-openssl --bin cargo-codspeed -- --target ${{ matrix.target }}
 
       - name: Upload Release Asset
         id: upload-release-asset

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,7 @@ dependencies = [
  "log",
  "memchr",
  "opener",
+ "openssl",
  "os_info",
  "pathdiff",
  "percent-encoding",
@@ -1545,6 +1546,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.25.0+1.1.1t"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,6 +1563,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/crates/cargo-codspeed/Cargo.toml
+++ b/crates/cargo-codspeed/Cargo.toml
@@ -29,3 +29,6 @@ assert_cmd = "2.0.7"
 fs_extra = "1.2.0"
 predicates = "2.1.4"
 uuid = { version = "1.2.2", features = ["v4"] }
+
+[features]
+vendored-openssl = ["cargo/vendored-openssl"]

--- a/crates/cargo-codspeed/README.md
+++ b/crates/cargo-codspeed/README.md
@@ -11,11 +11,27 @@ A cargo subcommand for running CodSpeed on your project
 
 ## Installation
 
+### With `cargo-binstall`(recommended)
+
+[`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) enables you to install binaries directly without having to build from the source(with `cargo install`) every time.
+
+If you don't have installed yet, you can install it with:
+
+```bash
+cargo install cargo-binstall
+```
+
+You can then install `cargo-codspeed` with:
+
+```bash
+cargo binstall cargo-codspeed
+```
+
+### With `cargo`
+
 ```bash
 cargo install cargo-codspeed
 ```
-
-Feature `vendored-openssl` can be used to statically link with openssl with `cargo install cargo-codspeed --features vendored-openssl`.
 
 ## Usage
 
@@ -30,3 +46,7 @@ Options:
   -h, --help     Print help information
   -V, --version  Print version information
 ```
+
+## Advanced Usage
+
+The `vendored-openssl` feature can be used to statically link with openssl with `cargo install cargo-codspeed --features vendored-openssl`.

--- a/crates/cargo-codspeed/README.md
+++ b/crates/cargo-codspeed/README.md
@@ -15,6 +15,8 @@ A cargo subcommand for running CodSpeed on your project
 cargo install cargo-codspeed
 ```
 
+Feature `vendored-openssl` can be used to statically link with openssl with `cargo install cargo-codspeed --features vendored-openssl`.
+
 ## Usage
 
 ```


### PR DESCRIPTION
# Summary

I failed to install `cargo-codspeed` locally due to not having openssl installed on system (nix).

```
  --- stderr
  Package openssl was not found in the pkg-config search path.
  Perhaps you should add the directory containing `openssl.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'openssl' found
```

This PR adds the `vendored-openssl` feature from `cargo`.

# Test plan

I made sure this got built successfully with `cargo build --release --features vendored-openssl` and then run the built binary against by project.