### PR TITLE
chore(cargo-codspeed): set verbosity to normal

### DIFF
--- a/crates/cargo-codspeed/src/build.rs
+++ b/crates/cargo-codspeed/src/build.rs
@@ -6,7 +6,7 @@ use crate::{
 use std::{collections::BTreeSet, fs::create_dir_all, rc::Rc};
 
 use cargo::{
-    core::{FeatureValue, Package, Workspace},
+    core::{FeatureValue, Package, Verbosity, Workspace},
     ops::{CompileFilter, CompileOptions, Packages},
     util::{command_prelude::CompileMode, interning::InternedString},
     Config,
@@ -76,6 +76,7 @@ pub fn build_benches(
         all_benches
     };
 
+    ws.config().shell().set_verbosity(Verbosity::Normal);
     ws.config().shell().status_with_color(
         "Collected",
         format!(


### PR DESCRIPTION
# Summary

`cargo codspeed` is printing with `--verbose`, which fills the log with lots of compilation messages that are uninteresting to normal users. 

e.g. build benchmark step in https://github.com/web-infra-dev/oxc/actions/runs/6095539763/job/16539311128
![image](https://github.com/CodSpeedHQ/codspeed-rust/assets/1430279/be98b641-81c3-4ac8-8c8f-8f0ed628f633)

This PR sets the verbosity to normal.

# Test Plan

I ran the built binary on my project and sees no compilation messages.
