### PR TITLE
Fix typo in `cargo build` release instruction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
       #   if: ${{ matrix.setup }}
       #   run: ${{ matrix.setup }}
 
-      - run: cargo build --release --features vendored-openssl --bin cargo-codspeed -- --target ${{ matrix.target }}
+      - run: cargo build --release --features vendored-openssl --bin cargo-codspeed --target ${{ matrix.target }}
 
       - name: Upload Release Asset
         id: upload-release-asset


### PR DESCRIPTION
Looks like uploading your prebuilt binaries failed, https://github.com/CodSpeedHQ/codspeed-rust/actions/runs/6576298954/job/17865786647#step:4:8

Think this should fix it.
