### PR TITLE
fix(criterion): benchmark group generics breaking change

### DIFF
--- a/crates/bencher_compat/README.md
+++ b/crates/bencher_compat/README.md
@@ -4,6 +4,7 @@
 [![CI](https://github.com/CodSpeedHQ/codspeed-rust/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/CodSpeedHQ/codspeed-rust/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/codspeed-bencher-compat)](https://crates.io/crates/codspeed-bencher-compat)
 [![Discord](https://img.shields.io/badge/chat%20on-discord-7289da.svg)](https://discord.com/invite/MxpaCfKSqF)
+[![CodSpeed Badge](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/CodSpeedHQ/codspeed-rust)
 
 Bencher compatibility layer for CodSpeed
 

--- a/crates/cargo-codspeed/README.md
+++ b/crates/cargo-codspeed/README.md
@@ -4,6 +4,7 @@
 [![CI](https://github.com/CodSpeedHQ/codspeed-rust/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/CodSpeedHQ/codspeed-rust/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/cargo-codspeed)](https://crates.io/crates/cargo-codspeed)
 [![Discord](https://img.shields.io/badge/chat%20on-discord-7289da.svg)](https://discord.com/invite/MxpaCfKSqF)
+[![CodSpeed Badge](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/CodSpeedHQ/codspeed-rust)
 
 A cargo subcommand for running CodSpeed on your project
 

--- a/crates/codspeed/README.md
+++ b/crates/codspeed/README.md
@@ -4,6 +4,7 @@
 [![CI](https://github.com/CodSpeedHQ/codspeed-rust/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/CodSpeedHQ/codspeed-rust/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/codspeed)](https://crates.io/crates/codspeed)
 [![Discord](https://img.shields.io/badge/chat%20on-discord-7289da.svg)](https://discord.com/invite/MxpaCfKSqF)
+[![CodSpeed Badge](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/CodSpeedHQ/codspeed-rust)
 
 The core library used to integrate with Codspeed runners
 

--- a/crates/criterion_compat/README.md
+++ b/crates/criterion_compat/README.md
@@ -4,6 +4,7 @@
 [![CI](https://github.com/CodSpeedHQ/codspeed-rust/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/CodSpeedHQ/codspeed-rust/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/codspeed-criterion-compat)](https://crates.io/crates/codspeed-criterion-compat)
 [![Discord](https://img.shields.io/badge/chat%20on-discord-7289da.svg)](https://discord.com/invite/MxpaCfKSqF)
+[![CodSpeed Badge](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/CodSpeedHQ/codspeed-rust)
 
 Criterion.rs compatibility layer for CodSpeed
 

--- a/crates/criterion_compat/src/compat/group.rs
+++ b/crates/criterion_compat/src/compat/group.rs
@@ -9,15 +9,15 @@ use crate::{Bencher, Criterion};
 
 /// Deprecated: using the default measurement will be removed in the next major version.
 /// Defaulting to WallTime differs from the original BenchmarkGroup implementation but avoids creating a breaking change
-pub struct BenchmarkGroup<M: Measurement = WallTime> {
+pub struct BenchmarkGroup<'a, M: Measurement = WallTime> {
     codspeed: Rc<RefCell<CodSpeed>>,
     current_file: String,
     macro_group: String,
     group_name: String,
-    _marker: PhantomData<*const M>,
+    _marker: PhantomData<&'a M>,
 }
 
-impl<M: Measurement> BenchmarkGroup<M> {
+impl<'a, M: Measurement> BenchmarkGroup<'a, M> {
     pub fn new(criterion: &mut Criterion<M>, group_name: String) -> BenchmarkGroup<M> {
         BenchmarkGroup::<M> {
             codspeed: criterion
@@ -79,7 +79,7 @@ impl<M: Measurement> BenchmarkGroup<M> {
 
 // Dummy methods
 #[allow(unused_variables)]
-impl<M: Measurement> BenchmarkGroup<M> {
+impl<'a, M: Measurement> BenchmarkGroup<'a, M> {
     pub fn sample_size(&mut self, n: usize) -> &mut Self {
         self
     }

--- a/crates/criterion_compat/src/compat/group.rs
+++ b/crates/criterion_compat/src/compat/group.rs
@@ -2,16 +2,19 @@ use std::marker::PhantomData;
 use std::{cell::RefCell, rc::Rc, time::Duration};
 
 use codspeed::{codspeed::CodSpeed, utils::get_git_relative_path};
+use criterion::measurement::WallTime;
 use criterion::{measurement::Measurement, PlotConfiguration, SamplingMode, Throughput};
 
 use crate::{Bencher, Criterion};
 
-pub struct BenchmarkGroup<M: Measurement> {
+/// Deprecated: using the default measurement will be removed in the next major version.
+/// Defaulting to WallTime differs from the original BenchmarkGroup implementation but avoids creating a breaking change
+pub struct BenchmarkGroup<M: Measurement = WallTime> {
     codspeed: Rc<RefCell<CodSpeed>>,
     current_file: String,
     macro_group: String,
     group_name: String,
-    phantom: PhantomData<*const M>,
+    _marker: PhantomData<*const M>,
 }
 
 impl<M: Measurement> BenchmarkGroup<M> {
@@ -25,7 +28,7 @@ impl<M: Measurement> BenchmarkGroup<M> {
             current_file: criterion.current_file.clone(),
             macro_group: criterion.macro_group.clone(),
             group_name,
-            phantom: PhantomData,
+            _marker: PhantomData,
         }
     }
 


### PR DESCRIPTION
- chore: add codspeed badges in sub readmes
- fix(criterion): add a default measurement to the benchmark group struct
- feat(criterion): support explicit lifetime for BenchmarkGroup
