### PR TITLE
feat(cargo-codspeed): build all benches in a single cargo build

### DIFF
--- a/crates/cargo-codspeed/Cargo.toml
+++ b/crates/cargo-codspeed/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["codspeed", "benchmark", "cargo"]
 
 [dependencies]
 cargo = "0.66.0"
-clap = { version = "4.0.29", features = ["derive"] }
+clap = { version = "=4.0.29", features = ["derive"] }
 termcolor = "1.0"
 anyhow = "1.0.66"
 itertools = "0.10.5"

--- a/crates/cargo-codspeed/src/prelude.rs
+++ b/crates/cargo-codspeed/src/prelude.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 pub use anyhow::{anyhow, bail, Error, Ok, Result};
 pub use cargo::core::Workspace;
 pub use itertools::Itertools;

--- a/crates/criterion_compat/src/compat/mod.rs
+++ b/crates/criterion_compat/src/compat/mod.rs
@@ -6,4 +6,3 @@ mod macros;
 pub use self::bencher::*;
 pub use self::criterion::*;
 pub use self::group::*;
-pub use self::macros::*;


### PR DESCRIPTION
As pointed out by @Boshen in https://github.com/oxc-project/oxc/pull/2343, we can build all the benches in a single command.