### PR TITLE
fix: Fixed path strip panic on Windows

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,8 @@
   "rust-analyzer.cargo.extraEnv": {
     "RUSTFLAGS": "--cfg codspeed"
   },
-  "rust-analyzer.cargo.allFeatures": true,
-  "rust-analyzer.checkOnSave.command": "clippy"
+  "rust-analyzer.cargo.features": "all",
+  "editor.formatOnSave": true,
+  "rust-analyzer.checkOnSave": true,
+  "rust-analyzer.check.command": "clippy"
 }

--- a/crates/codspeed/src/utils.rs
+++ b/crates/codspeed/src/utils.rs
@@ -18,6 +18,7 @@ where
     P: AsRef<Path>,
 {
     if let Ok(canonicalized_abs_path) = abs_path.as_ref().canonicalize() {
+        // `repo_path` is still canonicalized as it is a subpath of `canonicalized_abs_path`
         if let Ok(repo_path) = get_parent_git_repo_path(&canonicalized_abs_path) {
             canonicalized_abs_path
                 .strip_prefix(repo_path)

--- a/crates/codspeed/src/utils.rs
+++ b/crates/codspeed/src/utils.rs
@@ -17,14 +17,16 @@ pub fn get_git_relative_path<P>(abs_path: P) -> PathBuf
 where
     P: AsRef<Path>,
 {
-    let abs_path = abs_path.as_ref();
-    match abs_path
-        .canonicalize()
-        .and_then(|p| get_parent_git_repo_path(&p))
-    {
-        Ok(repo_path) => abs_path.strip_prefix(repo_path).unwrap().to_path_buf(),
-        Err(_) => abs_path.to_path_buf(),
+    if let Ok(abs_path) = abs_path.as_ref().canonicalize() {
+        if let Ok(repo_path) = get_parent_git_repo_path(&abs_path) {
+            return abs_path
+                .strip_prefix(repo_path)
+                .expect("Repository path is malformed.")
+                .to_path_buf();
+        }
     }
+
+    abs_path.as_ref().to_path_buf()
 }
 
 /// Fixes spaces around `::` created by stringify!($function).

--- a/crates/codspeed/src/utils.rs
+++ b/crates/codspeed/src/utils.rs
@@ -17,16 +17,18 @@ pub fn get_git_relative_path<P>(abs_path: P) -> PathBuf
 where
     P: AsRef<Path>,
 {
-    if let Ok(abs_path) = abs_path.as_ref().canonicalize() {
-        if let Ok(repo_path) = get_parent_git_repo_path(&abs_path) {
-            return abs_path
+    if let Ok(canonicalized_abs_path) = abs_path.as_ref().canonicalize() {
+        if let Ok(repo_path) = get_parent_git_repo_path(&canonicalized_abs_path) {
+            canonicalized_abs_path
                 .strip_prefix(repo_path)
                 .expect("Repository path is malformed.")
-                .to_path_buf();
+                .to_path_buf()
+        } else {
+            canonicalized_abs_path
         }
+    } else {
+        abs_path.as_ref().to_path_buf()
     }
-
-    abs_path.as_ref().to_path_buf()
 }
 
 /// Fixes spaces around `::` created by stringify!($function).
@@ -62,6 +64,18 @@ mod tests {
 
         let relative_path = get_git_relative_path(&path_dir);
         assert_eq!(relative_path, path_dir.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn test_get_git_relative_path_not_found_with_symlink() {
+        let dir = tempdir().unwrap();
+        let path_dir = dir.path().join("folder");
+        fs::create_dir_all(&path_dir).unwrap();
+        let symlink = dir.path().join("symlink");
+        std::os::unix::fs::symlink(&path_dir, &symlink).unwrap();
+
+        let relative_path = get_git_relative_path(&symlink);
+        assert_eq!(relative_path, symlink.canonicalize().unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Closes https://github.com/CodSpeedHQ/codspeed-rust/issues/35

The problem was that `repo_path` was "canonicalized" but `abs_path` was not, and this broke it because paths on Window get the `\\?\` (UNC I think it's called?) thing added at the begining, this small difference made `strip_prefix` return an error. Now, both paths are "canonicalized" before used.

![image](https://github.com/CodSpeedHQ/codspeed-rust/assets/38158676/796ae9a9-d676-4600-aebb-04ac02e375ab)
