### PR TITLE
fix: allow building codspeed-rust on unsupported architectures

### DIFF
--- a/crates/codspeed/src/request/arch/unsupported.rs
+++ b/crates/codspeed/src/request/arch/unsupported.rs
@@ -1,0 +1,6 @@
+pub type Value = u32;
+
+#[inline(always)]
+pub unsafe fn send_client_request(_default: Value, _args: &[Value; 6]) -> Value {
+    panic!("Not implemented for this architecture");
+}

--- a/crates/codspeed/src/request/mod.rs
+++ b/crates/codspeed/src/request/mod.rs
@@ -27,3 +27,12 @@ mod arch;
 #[cfg(target_arch = "aarch64")]
 #[path = "arch/aarch64.rs"]
 mod arch;
+
+#[cfg(not(any(
+    target_arch = "x86_64",
+    target_arch = "x86",
+    target_arch = "arm",
+    target_arch = "aarch64"
+)))]
+#[path = "arch/unsupported.rs"]
+mod arch;


### PR DESCRIPTION
Fixes build on architecture we don't support instrumentation for yet: https://github.com/astral-sh/ruff/issues/12662
