### PR TITLE
Support ubuntu 22.04 in released binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Currently releases are compiled on the latest ubuntu release on github actions, currently this is ubuntu 24.04 but that will change in the future as new releases are made available.
This PR changes releases to be specifically built on ubuntu 22.04.

As a result of this change, cargo-codspeed binary releases will be compatible with both ubuntu 22.04 and ubuntu 24.04.
Whereas previously cargo-codspeed was only compatible with ubuntu 24.04.

This is because glibc is linked to the final binary and glibc is compatible only with the versions newer or the same as the version on the system it was built with.

Here is an example of the error hit when running on ubuntu 22.04:
<img width="1301" alt="image" src="https://github.com/user-attachments/assets/0c7c8aa3-cc40-470c-9b81-03d62b6d29e5" />

As a workaround I am compiling cargo-codspeed from source, but it would be a nice boost to CI completion time if we could instead make use of the precompiled binaries.