### PR TITLE
feat: add support for all-features and no-default-features

### DIFF
--- a/crates/cargo-codspeed/src/app.rs
+++ b/crates/cargo-codspeed/src/app.rs
@@ -53,6 +53,14 @@ enum Commands {
         #[arg(short = 'F', long)]
         features: Option<String>,
 
+        /// Activate all available features of all selected packages.
+        #[arg(long)]
+        all_features: bool,
+
+        /// Do not activate the `default` feature of the selected packages.
+        #[arg(long)]
+        no_default_features: bool,
+
         /// Build the benchmarks with the specified profile
         #[arg(long, default_value = "release")]
         profile: String,
@@ -75,8 +83,23 @@ pub fn run(args: impl Iterator<Item = OsString>) -> Result<()> {
         Commands::Build {
             filters,
             features,
+            all_features,
+            no_default_features,
             profile,
         } => {
+            let passthrough_flags = {
+                let mut passthrough_flags = Vec::new();
+
+                if all_features {
+                    passthrough_flags.push("--all-features".to_string());
+                }
+
+                if no_default_features {
+                    passthrough_flags.push("--no-default-features".to_string());
+                }
+
+                passthrough_flags
+            };
             let features =
                 features.map(|f| f.split([' ', ',']).map(|s| s.to_string()).collect_vec());
             build_benches(
@@ -86,6 +109,7 @@ pub fn run(args: impl Iterator<Item = OsString>) -> Result<()> {
                 profile,
                 cli.quiet,
                 measurement_mode,
+                passthrough_flags,
             )
         }
         Commands::Run { filters } => run_benches(&metadata, filters, measurement_mode),

--- a/crates/cargo-codspeed/src/build.rs
+++ b/crates/cargo-codspeed/src/build.rs
@@ -11,6 +11,7 @@ struct BuildOptions<'a> {
     filters: Filters,
     features: &'a Option<Vec<String>>,
     profile: &'a str,
+    passthrough_flags: &'a Vec<String>,
 }
 
 struct BuiltBench {
@@ -124,6 +125,8 @@ impl BuildOptions<'_> {
             cargo.arg("--features").arg(features.join(","));
         }
 
+        cargo.args(self.passthrough_flags);
+
         cargo.arg("--profile").arg(self.profile);
 
         self.filters.package.add_cargo_args(&mut cargo);
@@ -159,11 +162,13 @@ pub fn build_benches(
     profile: String,
     quiet: bool,
     measurement_mode: MeasurementMode,
+    passthrough_flags: Vec<String>,
 ) -> Result<()> {
     let built_benches = BuildOptions {
         filters,
         features: &features,
         profile: &profile,
+        passthrough_flags: &passthrough_flags,
     }
     .build(metadata, quiet, measurement_mode)?;
 

--- a/crates/cargo-codspeed/tests/features.in/Cargo.toml
+++ b/crates/cargo-codspeed/tests/features.in/Cargo.toml
@@ -10,7 +10,9 @@ codspeed = { path = "../../../codspeed" }
 codspeed-bencher-compat = { path = "../../../bencher_compat" }
 
 [features]
+default = ["default_feature"]
 sample_feature = []
+default_feature = []
 
 [workspace]
 

--- a/crates/cargo-codspeed/tests/features.in/benches/bench.rs
+++ b/crates/cargo-codspeed/tests/features.in/benches/bench.rs
@@ -1,18 +1,34 @@
 use codspeed::codspeed::black_box;
 use codspeed_bencher_compat::{benchmark_group, benchmark_main, Bencher};
 
+#[cfg(feature = "default_feature")]
+pub fn with_default_feature(bench: &mut Bencher) {
+    bench.iter(|| (0..100).fold(0, |x, y| black_box(x + y)))
+}
+
+#[cfg(not(feature = "default_feature"))]
+pub fn without_default_feature(bench: &mut Bencher) {
+    bench.iter(|| (0..100).fold(0, |x, y| black_box(x + y)))
+}
+
 #[cfg(not(feature = "sample_feature"))]
 pub fn without_feature(bench: &mut Bencher) {
     bench.iter(|| (0..100).fold(0, |x, y| black_box(x + y)))
 }
-#[cfg(not(feature = "sample_feature"))]
-benchmark_group!(benches, without_feature);
 
 #[cfg(feature = "sample_feature")]
 pub fn with_feature(bench: &mut Bencher) {
     bench.iter(|| (0..100).fold(0, |x, y| black_box(x + y)))
 }
-#[cfg(feature = "sample_feature")]
-benchmark_group!(benches, with_feature);
 
-benchmark_main!(benches);
+#[cfg(feature = "sample_feature")]
+benchmark_group!(sample_benches, with_feature);
+#[cfg(not(feature = "sample_feature"))]
+benchmark_group!(sample_benches, without_feature);
+
+#[cfg(feature = "default_feature")]
+benchmark_group!(default_benches, with_default_feature);
+#[cfg(not(feature = "default_feature"))]
+benchmark_group!(default_benches, without_default_feature);
+
+benchmark_main!(sample_benches, default_benches);

--- a/crates/cargo-codspeed/tests/features.rs
+++ b/crates/cargo-codspeed/tests/features.rs
@@ -37,3 +37,40 @@ fn test_with_feature() {
         .stdout(contains("without_feature").not());
     teardown(dir);
 }
+
+#[test]
+fn test_no_default_features() {
+    let dir = setup(DIR, Project::Features);
+    cargo_codspeed(&dir)
+        .arg("build")
+        .arg("--no-default-features")
+        .assert()
+        .success();
+    cargo_codspeed(&dir)
+        .arg("run")
+        .assert()
+        .success()
+        .stderr(contains("Finished running 1 benchmark suite(s)"))
+        .stdout(contains("with_default_feature").not())
+        .stdout(contains("without_default_feature"));
+
+    teardown(dir);
+}
+
+#[test]
+fn test_all_features() {
+    let dir = setup(DIR, Project::Features);
+    cargo_codspeed(&dir)
+        .arg("build")
+        .arg("--all-features")
+        .assert()
+        .success();
+    cargo_codspeed(&dir)
+        .arg("run")
+        .assert()
+        .success()
+        .stderr(contains("Finished running 1 benchmark suite(s)"))
+        .stdout(contains("with_feature"))
+        .stdout(contains("with_default_feature"));
+    teardown(dir);
+}


### PR DESCRIPTION
Added `passthrough_flags` to the `BuildOptions` which can be used to add more flags in the future if needed. 

Closes #57 