### PR TITLE
Cod 711 file name missing in codspeed rust flamegraph

### DIFF
--- a/crates/cargo-codspeed/src/build.rs
+++ b/crates/cargo-codspeed/src/build.rs
@@ -115,6 +115,15 @@ impl BuildOptions<'_> {
         // Add debug info (equivalent to -g)
         rust_flags.push_str(" -C debuginfo=2");
 
+        // Prevent debug info stripping
+        // https://doc.rust-lang.org/cargo/reference/profiles.html#release
+        // According to cargo docs, for release profile which we default to:
+        // `strip = "none"` and `debug = false`.
+        // In practice, if we set debug info through RUSTFLAGS, cargo still strips them, most
+        // likely because debug = false in the release profile.
+        // We also need to disable stripping through rust flags.
+        rust_flags.push_str(" -C strip=none");
+
         // Add the codspeed cfg flag if instrumentation mode is enabled
         if measurement_mode == MeasurementMode::Instrumentation {
             rust_flags.push_str(" --cfg codspeed");

--- a/crates/divan_compat/benches/basic_example.rs
+++ b/crates/divan_compat/benches/basic_example.rs
@@ -1,6 +1,6 @@
 use codspeed_divan_compat::Bencher;
 
-fn fibo(n: i32) -> i32 {
+fn fibo(n: u64) -> u64 {
     let mut a = 0;
     let mut b = 1;
 
@@ -14,12 +14,12 @@ fn fibo(n: i32) -> i32 {
 }
 
 #[codspeed_divan_compat::bench]
-fn fibo_500() -> i32 {
-    codspeed_divan_compat::black_box(fibo(500))
+fn fibo_50() -> u64 {
+    codspeed_divan_compat::black_box(fibo(50))
 }
 
 #[codspeed_divan_compat::bench]
-fn fibo_10() -> i32 {
+fn fibo_10() -> u64 {
     codspeed_divan_compat::black_box(fibo(10))
 }
 


### PR DESCRIPTION
- Root cause was missing debug symbols, because cargo seems to strip them by default if they are not explicitly enabled in `Cargo.toml` and only through rust flags (this is a theory, have not dived into cargo code)
- Noticed that fibo(500) is actually a very huge and overflowing integer when troubleshooting benches without release profile, so fixed it