### PR TITLE
chore(cargo-codspeed): bump `cargo_metadata` to v0.19.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8769706aad5d996120af43197bf46ef6ad0fda35216b4505f926a365a232d924"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",

--- a/crates/cargo-codspeed/Cargo.toml
+++ b/crates/cargo-codspeed/Cargo.toml
@@ -18,7 +18,7 @@ categories = [
 keywords = ["codspeed", "benchmark", "cargo"]
 
 [dependencies]
-cargo_metadata = "0.19.1"
+cargo_metadata = "0.19.2"
 clap = { version = "=4.5.17", features = ["derive", "env"] }
 termcolor = "1.4"
 anyhow = "1.0.86"


### PR DESCRIPTION
The current version fails `failed to parse manifest at `/path/to/oxc/bench-javascript-transformer-written-in-rust/Cargo.toml` with 

```toml
[package]
edition = "2024"
```