### PR TITLE
fix: do not display error when sending benchmark uri

### DIFF
--- a/crates/codspeed/src/utils.rs
+++ b/crates/codspeed/src/utils.rs
@@ -38,6 +38,10 @@ pub fn get_formated_function_path(function_path: impl Into<String>) -> String {
     function_path.replace(" :: ", "::")
 }
 
+pub fn running_with_codspeed_runner() -> bool {
+    std::env::var("CODSPEED_ENV").is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/codspeed/src/walltime.rs
+++ b/crates/codspeed/src/walltime.rs
@@ -58,7 +58,7 @@ pub fn collect_raw_walltime_results(
     max_time_ns: Option<u128>,
     times_ns: Vec<u128>,
 ) {
-    if std::env::var("CODSPEED_ENV").is_err() {
+    if !crate::utils::running_with_codspeed_runner() {
         return;
     }
     let workspace_root = std::env::var("CODSPEED_CARGO_WORKSPACE_ROOT").map(PathBuf::from);

--- a/crates/criterion_compat/criterion_fork/src/analysis/mod.rs
+++ b/crates/criterion_compat/criterion_fork/src/analysis/mod.rs
@@ -257,7 +257,7 @@ pub(crate) fn common<M: Measurement, T: ?Sized>(
         }
     }
 
-    if criterion.should_save_baseline() && std::env::var("CODSPEED_ENV").is_ok() {
+    if criterion.should_save_baseline() && ::codspeed::utils::running_with_codspeed_runner() {
         codspeed::collect_walltime_results(id, criterion, &iters, avg_times);
     }
 }
@@ -301,7 +301,7 @@ mod codspeed {
             pid: std::process::id(),
             uri: uri.clone(),
         }) {
-            if std::env::var("CODSPEED_ENV").is_ok() {
+            if codspeed::utils::running_with_codspeed_runner() {
                 eprintln!("Failed to send benchmark URI to runner: {error:?}");
             }
         }

--- a/crates/criterion_compat/criterion_fork/src/analysis/mod.rs
+++ b/crates/criterion_compat/criterion_fork/src/analysis/mod.rs
@@ -301,7 +301,9 @@ mod codspeed {
             pid: std::process::id(),
             uri: uri.clone(),
         }) {
-            eprintln!("Failed to send benchmark URI to runner: {}", error);
+            if std::env::var("CODSPEED_ENV").is_ok() {
+                eprintln!("Failed to send benchmark URI to runner: {error:?}");
+            }
         }
 
         let avg_iter_per_round = iters.iter().sum::<f64>() / iters.len() as f64;

--- a/crates/criterion_compat/criterion_fork/src/macros.rs
+++ b/crates/criterion_compat/criterion_fork/src/macros.rs
@@ -68,7 +68,7 @@ macro_rules! criterion_group {
             let mut criterion: $crate::Criterion<_> = $config
                 .configure_from_args();
             $(
-                if std::env::var("CODSPEED_ENV").is_ok() {
+                if codspeed::utils::running_with_codspeed_runner()  {
                     criterion.set_current_file($crate::abs_file!());
                     criterion.set_macro_group(format!("{}::{}", stringify!($name), stringify!($target)));
                 }

--- a/crates/divan_compat/divan_fork/src/divan.rs
+++ b/crates/divan_compat/divan_fork/src/divan.rs
@@ -432,7 +432,9 @@ mod codspeed {
             pid: std::process::id(),
             uri: uri.clone(),
         }) {
-            eprintln!("Failed to send benchmark URI to runner: {}", error);
+            if std::env::var("CODSPEED_ENV").is_ok() {
+                eprintln!("Failed to send benchmark URI to runner: {error:?}");
+            }
         }
 
         ::codspeed::walltime::collect_raw_walltime_results(

--- a/crates/divan_compat/divan_fork/src/divan.rs
+++ b/crates/divan_compat/divan_fork/src/divan.rs
@@ -432,7 +432,7 @@ mod codspeed {
             pid: std::process::id(),
             uri: uri.clone(),
         }) {
-            if std::env::var("CODSPEED_ENV").is_ok() {
+            if codspeed::utils::running_with_codspeed_runner() {
                 eprintln!("Failed to send benchmark URI to runner: {error:?}");
             }
         }


### PR DESCRIPTION
Previous output (different project): 
```
[11:15] not-matthias:perf-walltime-repo (main)> cargo codspeed run                                                                                                                                                                                                      devenv-shell-env
[cargo-codspeed] Measurement mode: Walltime

Collected 1 benchmark suite(s) to run
Running perf-walltime-repo my_benchmark
Timer precision: 24 ns
my_benchmark  fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ fibonacci                │               │               │               │         │
   ╰─ 32      Failed to send benchmark URI to runner: FIFO does not exist: /tmp/runner.ctl.fifo
4.382 ms      │ 11.75 ms      │ 5.129 ms      │ 5.862 ms      │ 510     │ 510

Done running my_benchmark
Finished running 1 benchmark suite(s)
No walltime benchmarks found
```

Works now as expected: 
```
[11:22] not-matthias:divan_compat (cod-856-errror-log-in-walltime-when-running-without-codspeed)> cargo codspeed run                                                                                                                       devenv-shell-env
[cargo-codspeed] Measurement mode: Walltime

Collected 1 benchmark suite(s) to run
Running codspeed-divan-compat basic_example
Timer precision: 19 ns
basic_example       fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ fibo_10          0.135 ns      │ 1.141 ns      │ 0.207 ns      │ 0.22 ns       │ 100     │ 409600
├─ fibo_50          0.108 ns      │ 0.509 ns      │ 0.199 ns      │ 0.205 ns      │ 100     │ 409600
├─ mut_borrow       0.405 ns      │ 148 ns        │ 0.603 ns      │ 3.929 ns      │ 100     │ 25600
╰─ const_bench                    │               │               │               │         │
   ├─ bench_array1                │               │               │               │         │
   │  ├─ 1          0.107 ns      │ 0.287 ns      │ 0.11 ns       │ 0.125 ns      │ 100     │ 409600
   │  ├─ 4          5.386 ns      │ 5.849 ns      │ 5.401 ns      │ 5.409 ns      │ 100     │ 51200
   │  ├─ 10         7.784 ns      │ 19.87 ns      │ 7.866 ns      │ 8.061 ns      │ 100     │ 25600
   │  ╰─ 42         26.46 ns      │ 36.87 ns      │ 26.73 ns      │ 27.43 ns      │ 100     │ 12800
   ├─ bench_array2                │               │               │               │         │
   │  ├─ 1          0.032 ns      │ 0.37 ns       │ 0.108 ns      │ 0.108 ns      │ 100     │ 409600
   │  ├─ 4          4.521 ns      │ 5.552 ns      │ 4.534 ns      │ 4.554 ns      │ 100     │ 51200
   │  ├─ 10         6.569 ns      │ 8.569 ns      │ 6.636 ns      │ 6.658 ns      │ 100     │ 25600
   │  ╰─ 42         22.34 ns      │ 38.14 ns      │ 22.67 ns      │ 23.73 ns      │ 100     │ 12800
   ╰─ init_array                  │               │               │               │         │
      ├─ 4          4.522 ns      │ 7.954 ns      │ 4.542 ns      │ 4.983 ns      │ 100     │ 51200
      ├─ 42         22.3 ns       │ 29.2 ns       │ 22.59 ns      │ 22.71 ns      │ 100     │ 12800
      ╰─ 1000       513.3 ns      │ 1.078 µs      │ 551.1 ns      │ 557.2 ns      │ 100     │ 400

Done running basic_example
Finished running 1 benchmark suite(s)
No walltime benchmarks found
```