### PR TITLE
feat: change default profile from release to bench for build command

### DIFF
--- a/crates/cargo-codspeed/src/app.rs
+++ b/crates/cargo-codspeed/src/app.rs
@@ -66,7 +66,7 @@ enum Commands {
         jobs: Option<u32>,
 
         /// Build the benchmarks with the specified profile
-        #[arg(long, default_value = "release")]
+        #[arg(long, default_value = "bench")]
         profile: String,
     },
     /// Run the previously built benchmarks


### PR DESCRIPTION
## Summary
- Changes the default profile for `cargo codspeed build` from `release` to `bench`
- Aligns with standard Rust benchmarking workflow (`cargo bench` defaults to `--profile bench`)
- Allows users to leverage bench profile customizations while maintaining compatibility

## Test plan
- [x] Verify the change compiles without errors
- [x] Confirm pre-commit hooks pass
- [ ] Test that `cargo codspeed build` now uses bench profile by default
- [ ] Ensure existing workflows continue to work with explicit `--profile release`

Fixes #60 

🤖 Generated with [Claude Code](https://claude.ai/code)