### PR TITLE
chore: bump rust toolchain to 1.88.0

### DIFF
--- a/crates/cargo-codspeed/src/build.rs
+++ b/crates/cargo-codspeed/src/build.rs
@@ -56,7 +56,7 @@ impl BuildOptions<'_> {
                     println!("{}", &msg.message);
                 }
                 Message::TextLine(line) => {
-                    println!("{}", line);
+                    println!("{line}");
                 }
                 Message::CompilerArtifact(artifact)
                     if artifact.target.is_kind(TargetKind::Bench) =>

--- a/crates/cargo-codspeed/src/main.rs
+++ b/crates/cargo-codspeed/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
     };
 
     if let Err(e) = app::run(args_vec.into_iter()) {
-        eprintln!("{}", e);
+        eprintln!("{e}");
         exit(1);
     }
 }

--- a/crates/cargo-codspeed/src/run.rs
+++ b/crates/cargo-codspeed/src/run.rs
@@ -161,14 +161,11 @@ pub fn run_benches(
                         .or(status.signal().map(|s| 128 + s)) // 128+N indicates that a command was interrupted by signal N (see: https://tldp.org/LDP/abs/html/exitcodes.html)
                         .unwrap_or(1);
 
-                    eprintln!(
-                        "failed to execute the benchmark process, exit code: {}",
-                        code
-                    );
+                    eprintln!("failed to execute the benchmark process, exit code: {code}");
                     std::process::exit(code);
                 }
             })?;
-        eprintln!("Done running {}", bench_name);
+        eprintln!("Done running {bench_name}");
     }
     eprintln!("Finished running {} benchmark suite(s)", to_run.len());
 

--- a/crates/cargo-codspeed/tests/helpers.rs
+++ b/crates/cargo-codspeed/tests/helpers.rs
@@ -32,7 +32,7 @@ pub fn setup(dir: &str, project: Project) -> String {
     copy_opts.content_only = true;
     copy(dir, &tmp_dir, &copy_opts).unwrap();
     if env::var("DEBUG").is_ok() {
-        println!("tmp_dir={:?}", tmp_dir);
+        println!("tmp_dir={tmp_dir:?}");
     }
 
     let package_root = PathBuf::from_str(env!("CARGO_MANIFEST_DIR")).unwrap();

--- a/crates/codspeed/src/walltime_results.rs
+++ b/crates/codspeed/src/walltime_results.rs
@@ -192,7 +192,7 @@ impl WalltimeBenchmark {
         let output_dir = result_dir_from_workspace_root(workspace_root).join(scope);
         std::fs::create_dir_all(&output_dir).unwrap();
         let bench_id = uuid::Uuid::new_v4().to_string();
-        let output_path = output_dir.join(format!("{}.json", bench_id));
+        let output_path = output_dir.join(format!("{bench_id}.json"));
         let mut writer = std::fs::File::create(&output_path).expect("Failed to create the file");
         serde_json::to_writer_pretty(&mut writer, self).expect("Failed to write the data");
         writer.flush().expect("Failed to flush the writer");

--- a/crates/criterion_compat/src/compat/group.rs
+++ b/crates/criterion_compat/src/compat/group.rs
@@ -68,10 +68,10 @@ impl<'a, M: Measurement> BenchmarkGroup<'a, M> {
             self.group_name,
         );
         if let Some(function_name) = id.function_name {
-            uri = format!("{}::{}", uri, function_name);
+            uri = format!("{uri}::{function_name}");
         }
         if let Some(parameter) = id.parameter {
-            uri = format!("{}[{}]", uri, parameter);
+            uri = format!("{uri}[{parameter}]");
         }
         let mut b = Bencher::new(self.codspeed.clone(), uri);
         f(&mut b, input);
@@ -129,7 +129,7 @@ impl BenchmarkId {
     ) -> BenchmarkId {
         BenchmarkId {
             function_name: Some(function_name.into()),
-            parameter: Some(format!("{}", parameter)),
+            parameter: Some(format!("{parameter}")),
         }
     }
 
@@ -138,7 +138,7 @@ impl BenchmarkId {
     pub fn from_parameter<P: ::std::fmt::Display>(parameter: P) -> BenchmarkId {
         BenchmarkId {
             function_name: None,
-            parameter: Some(format!("{}", parameter)),
+            parameter: Some(format!("{parameter}")),
         }
     }
 
@@ -152,7 +152,7 @@ impl BenchmarkId {
     pub(crate) fn no_function_with_input<P: ::std::fmt::Display>(parameter: P) -> BenchmarkId {
         BenchmarkId {
             function_name: None,
-            parameter: Some(format!("{}", parameter)),
+            parameter: Some(format!("{parameter}")),
         }
     }
 }

--- a/crates/divan_compat/divan_fork/src/entry/generic.rs
+++ b/crates/divan_compat/divan_fork/src/entry/generic.rs
@@ -153,7 +153,7 @@ impl EntryConst {
     /// Returns [`PartialOrd::partial_cmp`] ordering if `<` or `>, falling back
     /// to comparing [`ToString::to_string`] otherwise.
     pub(crate) fn cmp_name(&self, other: &Self) -> Ordering {
-        if self.partial_cmp == other.partial_cmp {
+        if self.partial_cmp as usize == other.partial_cmp as usize {
             // SAFETY: Both constants have the same comparison function, so they
             // must be the same type.
             if let Some(ordering) = unsafe { (self.partial_cmp)(self.value, other.value) } {

--- a/crates/divan_compat/examples/benches/env.rs
+++ b/crates/divan_compat/examples/benches/env.rs
@@ -5,5 +5,5 @@ fn main() {
 #[divan::bench]
 fn print_env_hello() {
     let env_var = std::env::var("MY_ENV_VAR").unwrap_or("not set".to_string());
-    println!("MY_ENV_VAR is {}", env_var);
+    println!("MY_ENV_VAR is {env_var}");
 }

--- a/crates/divan_compat/src/compat/mod.rs
+++ b/crates/divan_compat/src/compat/mod.rs
@@ -58,7 +58,7 @@ pub fn main() {
         if let Some(options) = &meta.bench_options {
             if let Some(true) = options.ignore {
                 let uri = uri::generate(&entry, entry.display_name());
-                println!("Skipped: {}", uri);
+                println!("Skipped: {uri}");
                 continue;
             }
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84"
+channel = "1.88"


### PR DESCRIPTION
## Summary
- Bump Rust toolchain from 1.80.0 to 1.88.0
- Fix all clippy warnings that arose from the new toolchain version
- Update code to use inline format variables as required by clippy::uninlined-format-args

## Changes
- Updated `rust-toolchain.toml` to specify version 1.88.0
- Fixed ~10 instances of format string warnings across multiple crates
- Replaced `std::ptr::fn_addr_eq` with pointer casting to maintain MSRV compatibility

## Test plan
- [x] All pre-commit hooks pass
- [x] `cargo fmt --all` runs successfully
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.ai/code)