### PR TITLE
feat: add Windows build support

### DIFF
--- a/crates/codspeed/src/lib.rs
+++ b/crates/codspeed/src/lib.rs
@@ -1,5 +1,8 @@
 pub mod codspeed;
+
+#[cfg(unix)]
 pub mod fifo;
+
 mod macros;
 mod measurement;
 mod request;

--- a/crates/codspeed/src/shared.rs
+++ b/crates/codspeed/src/shared.rs
@@ -1,6 +1,8 @@
 //! WARNING: Has to be in sync with `runner`.
 
+#[cfg(unix)]
 pub const RUNNER_CTL_FIFO: &str = "/tmp/runner.ctl.fifo";
+#[cfg(unix)]
 pub const RUNNER_ACK_FIFO: &str = "/tmp/runner.ack.fifo";
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]

--- a/crates/codspeed/src/utils.rs
+++ b/crates/codspeed/src/utils.rs
@@ -71,6 +71,7 @@ mod tests {
         assert_eq!(relative_path, path_dir.canonicalize().unwrap());
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_get_git_relative_path_not_found_with_symlink() {
         let dir = tempdir().unwrap();

--- a/crates/criterion_compat/criterion_fork/src/analysis/mod.rs
+++ b/crates/criterion_compat/criterion_fork/src/analysis/mod.rs
@@ -297,12 +297,17 @@ mod codspeed {
     ) {
         let (uri, bench_name) = create_uri_and_name(id, c);
 
-        if let Err(error) = ::codspeed::fifo::send_cmd(codspeed::fifo::Command::CurrentBenchmark {
-            pid: std::process::id(),
-            uri: uri.clone(),
-        }) {
-            if codspeed::utils::running_with_codspeed_runner() {
-                eprintln!("Failed to send benchmark URI to runner: {error:?}");
+        #[cfg(unix)]
+        {
+            if let Err(error) =
+                ::codspeed::fifo::send_cmd(codspeed::fifo::Command::CurrentBenchmark {
+                    pid: std::process::id(),
+                    uri: uri.clone(),
+                })
+            {
+                if codspeed::utils::running_with_codspeed_runner() {
+                    eprintln!("Failed to send benchmark URI to runner: {error:?}");
+                }
             }
         }
 

--- a/crates/criterion_compat/criterion_fork/src/routine.rs
+++ b/crates/criterion_compat/criterion_fork/src/routine.rs
@@ -192,6 +192,7 @@ pub(crate) trait Routine<M: Measurement, T: ?Sized> {
         }
 
         let m_elapsed = {
+            #[cfg(unix)]
             let _guard = codspeed::fifo::BenchGuard::new_with_runner_fifo();
             self.bench(measurement, &m_iters, parameter)
         };

--- a/crates/divan_compat/divan_fork/src/bench/mod.rs
+++ b/crates/divan_compat/divan_fork/src/bench/mod.rs
@@ -657,6 +657,7 @@ impl<'a> BenchContext<'a> {
 
         let bench_overheads = timer.bench_overheads();
 
+        #[cfg(unix)]
         let _guard = codspeed::fifo::BenchGuard::new_with_runner_fifo();
         while {
             // Conditions for when sampling is over:
@@ -811,6 +812,7 @@ impl<'a> BenchContext<'a> {
                 elapsed_picos = elapsed_picos.saturating_add(progress_picos);
             }
         }
+        #[cfg(unix)]
         core::mem::drop(_guard);
 
         // Reset flag for ignoring allocations.

--- a/crates/divan_compat/divan_fork/src/divan.rs
+++ b/crates/divan_compat/divan_fork/src/divan.rs
@@ -430,12 +430,17 @@ mod codspeed {
             bench_context.samples.time_samples.iter().map(|s| s.duration.picos / 1_000).collect();
         let max_time_ns = bench_context.options.max_time.map(|t| t.as_nanos());
 
-        if let Err(error) = ::codspeed::fifo::send_cmd(codspeed::fifo::Command::CurrentBenchmark {
-            pid: std::process::id(),
-            uri: uri.clone(),
-        }) {
-            if codspeed::utils::running_with_codspeed_runner() {
-                eprintln!("Failed to send benchmark URI to runner: {error:?}");
+        #[cfg(unix)]
+        {
+            if let Err(error) =
+                ::codspeed::fifo::send_cmd(codspeed::fifo::Command::CurrentBenchmark {
+                    pid: std::process::id(),
+                    uri: uri.clone(),
+                })
+            {
+                if codspeed::utils::running_with_codspeed_runner() {
+                    eprintln!("Failed to send benchmark URI to runner: {error:?}");
+                }
             }
         }
 


### PR DESCRIPTION
Add conditional compilation for Unix-specific features to enable Windows builds:
- Wrap FIFO-related code with cfg(unix) attributes
- Use platform-specific exit status handling in cargo-codspeed
- Make fifo module Unix-only in lib.rs
- Guard FIFO constants and operations across all crates

This allows the project to build on Windows (build-only, not runtime support).

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
