### PR TITLE
fix: regression for handling rustflags from .cargo/config.toml

### DIFF
--- a/crates/cargo-codspeed/src/build.rs
+++ b/crates/cargo-codspeed/src/build.rs
@@ -145,8 +145,9 @@ impl BuildOptions<'_> {
                 // Use --config to set rustflags
                 // Our rust integration has an msrv of 1.74, --config is available since 1.63
                 // https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-163-2022-08-11
+                // Note: We have to use `target.cfg(all())` since `build` has a lower precedence.
                 let config_value = format!(
-                    "build.rustflags=[{}]",
+                    "target.'cfg(all())'.rustflags=[{}]",
                     flags.into_iter().map(|f| format!("\"{f}\"")).join(",")
                 );
                 cargo.arg("--config").arg(config_value);

--- a/crates/cargo-codspeed/tests/cargo_config.in/.cargo/config.toml
+++ b/crates/cargo-codspeed/tests/cargo_config.in/.cargo/config.toml
@@ -1,2 +1,10 @@
+# Note: This does nothing since `target.<cfg>.rustflags` takes precedence over `build.rustflags`
+# See: https://doc.rust-lang.org/nightly/cargo/reference/config.html#buildrustflags
 [build]
+rustflags = ["--cfg", "this_does_nothing"]
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["--cfg", "target_feature_flag"]
+
+[target.'cfg(all())']
 rustflags = ["--cfg", "custom_feature_flag"]

--- a/crates/cargo-codspeed/tests/cargo_config.in/benches/cargo_config_bench.rs
+++ b/crates/cargo-codspeed/tests/cargo_config.in/benches/cargo_config_bench.rs
@@ -8,6 +8,11 @@ fn bench_failing_without_custom_flag(c: &mut Criterion) {
             compile_error!(
                 "custom_feature_flag is not enabled - .cargo/config.toml rustflags not applied"
             );
+
+            #[cfg(not(target_feature_flag))]
+            compile_error!(
+                "target_feature_flag is not enabled - .cargo/config.toml rustflags not applied"
+            );
         })
     });
 }


### PR DESCRIPTION
If `target.<cfg>.rustflags` is set, our `build.rustflags` config value won't be used since it has a lower precedence (see: https://doc.rust-lang.org/nightly/cargo/reference/config.html#buildrustflags). We can solve this by using `target.cfg(all())` but this will override any `build.rustflags` values in the `.cargo/config.toml`. 