### PR TITLE
ci: install musl-tools before building for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
       - uses: moonrepo/setup-rust@v1
         with:
           targets: ${{ matrix.target }}


### PR DESCRIPTION
Tested here: https://github.com/CodSpeedHQ/codspeed-rust/actions/runs/18218174549/job/51872087395