### PR TITLE
Update colored dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,12 +710,11 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "colored"
-version = "2.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1176,12 +1175,6 @@ checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
 dependencies = [
  "log",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"

--- a/crates/bencher_compat/Cargo.toml
+++ b/crates/bencher_compat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "codspeed-bencher-compat"
 version = "4.7.0"
-rust-version = "1.74" # MSRV
+rust-version = "1.80" # MSRV
 edition = "2021"
 description = "Bencher compatibility layer for CodSpeed"
 authors = ["Arthur Pastel <arthur@codspeed.io>"]

--- a/crates/cargo-codspeed/Cargo.toml
+++ b/crates/cargo-codspeed/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-codspeed"
 version = "4.7.0"
-rust-version = "1.74" # MSRV
+rust-version = "1.80" # MSRV
 edition = "2021"
 description = "Cargo extension to build & run your codspeed benchmarks"
 authors = ["Arthur Pastel <arthur@codspeed.io>"]

--- a/crates/cargo-codspeed/src/build.rs
+++ b/crates/cargo-codspeed/src/build.rs
@@ -113,10 +113,9 @@ impl BuildOptions<'_> {
         let package_names = self
             .package_filters
             .packages_from_flags(metadata)
-            .map_err(|e| {
+            .inspect_err(|_e| {
                 // Avoid leaving an orphan cargo process, even if something went wrong
-                cargo.wait().expect("Could not get cargo's exist status");
-                e
+                cargo.wait().expect("Could not get cargo's exit status");
             })?
             .into_iter()
             .map(|t| t.name.clone())

--- a/crates/codspeed/Cargo.toml
+++ b/crates/codspeed/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "codspeed"
 version = "4.7.0"
-rust-version = "1.74" # MSRV
+rust-version = "1.80" # MSRV
 edition = "2021"
 description = "Core instrumentation library for CodSpeed"
 authors = ["Arthur Pastel <arthur@codspeed.io>"]

--- a/crates/codspeed/Cargo.toml
+++ b/crates/codspeed/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["codspeed", "benchmark"]
 
 [dependencies]
 anyhow = { workspace = true }
-colored = "2.0.0"
+colored = "3.0.0"
 glob = "0.3.2"
 libc = "^0.2"
 nix = { version = "0.31.1", features = ["time"] }

--- a/crates/criterion_compat/Cargo.toml
+++ b/crates/criterion_compat/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["codspeed", "benchmark", "criterion"]
 [dependencies]
 criterion = { package = "codspeed-criterion-compat-walltime", path = "./criterion_fork", version = "=4.7.0", default-features = false }
 codspeed = { path = "../codspeed", version = "=4.7.0" }
-colored = "2.1.0"
+colored = "3.0.0"
 clap = { version = "4", default-features = false, features = ["std"] }
 regex = { version = "1.5", default-features = false, features = ["std"] }
 

--- a/crates/criterion_compat/Cargo.toml
+++ b/crates/criterion_compat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "codspeed-criterion-compat"
 version = "4.7.0"
-rust-version = "1.74" # MSRV
+rust-version = "1.80" # MSRV
 edition = "2021"
 description = "Criterion.rs compatibility layer for CodSpeed"
 authors = ["Arthur Pastel <arthur@codspeed.io>"]


### PR DESCRIPTION
Mostly I just want to remove lazy_static from my dep tree, and colored 3.0.0 has removed its dependency on lazy_static.