### PR TITLE
fix(divan): use busy sleep in time scale examples

### DIFF
--- a/crates/divan_compat/examples/benches/time_scale.rs
+++ b/crates/divan_compat/examples/benches/time_scale.rs
@@ -2,24 +2,29 @@ fn main() {
     divan::main();
 }
 
+fn busy_sleep(duration: std::time::Duration) {
+    let start = std::time::Instant::now();
+    while start.elapsed() < duration {}
+}
+
 #[divan::bench]
 fn sleep_1ns() {
-    std::thread::sleep(std::time::Duration::from_nanos(1));
+    busy_sleep(std::time::Duration::from_nanos(1));
 }
 
 #[divan::bench]
 fn sleep_100ns() {
-    std::thread::sleep(std::time::Duration::from_nanos(100));
+    busy_sleep(std::time::Duration::from_nanos(100));
 }
 
 #[divan::bench]
 fn sleep_1us() {
-    std::thread::sleep(std::time::Duration::from_micros(1));
+    busy_sleep(std::time::Duration::from_micros(1));
 }
 
 #[divan::bench]
 fn sleep_100us() {
-    std::thread::sleep(std::time::Duration::from_micros(100));
+    busy_sleep(std::time::Duration::from_micros(100));
 }
 
 #[divan::bench]


### PR DESCRIPTION
For these times, using `thread::sleep` makes no sense as, at least on linux, the scheduler's timer resolution is orders of magnitude larger than nanoseconds.