### PR TITLE
fix: explicitely disable instrument hooks warnings

### DIFF
--- a/crates/codspeed/build.rs
+++ b/crates/codspeed/build.rs
@@ -7,9 +7,9 @@ fn main() {
 
     let mut build = cc::Build::new();
     build
-        .flag("-std=c11")
         .file("instrument-hooks/dist/core.c")
         .include("instrument-hooks/includes")
+        .std("c11")
         // We generated the C code from Zig, which contains some warnings
         // that can be safely ignored.
         .flag("-Wno-format")
@@ -18,15 +18,11 @@ fn main() {
         .flag("-Wno-unused-const-variable")
         .flag("-Wno-type-limits")
         .flag("-Wno-uninitialized")
-        // Ignore warnings when cross-compiling:
         .flag("-Wno-overflow")
         .flag("-Wno-unused-function")
         .flag("-Wno-constant-conversion")
         .flag("-Wno-incompatible-pointer-types")
-        // Disable warnings, as we will have lots of them
-        .warnings(false)
-        .extra_warnings(false)
-        .cargo_warnings(false)
+        .flag("-Wno-unterminated-string-initialization")
         .opt_level(3);
 
     let result = build.try_compile("instrument_hooks");


### PR DESCRIPTION
@not-matthias, we should be explicit about the warnings to ignore, skipping them all would create unseen issues
(bumped into that while building the exec-harness which needs most of those flags and we don't want to skip all warnings)