### PR TITLE
fix(cargo-codspeed): forward args after `--` to bench binaries

### DIFF
--- a/crates/cargo-codspeed/src/app.rs
+++ b/crates/cargo-codspeed/src/app.rs
@@ -100,6 +100,7 @@ impl Cli {
                 package_filters,
                 bench_target_filters,
                 measurement_mode,
+                bench_args,
             } => {
                 let mode = measurement_mode.unwrap_or_default();
                 eprintln!("[cargo-codspeed] Measurement mode: {mode:?}\n");
@@ -109,6 +110,7 @@ impl Cli {
                     package_filters,
                     bench_target_filters,
                     mode,
+                    bench_args,
                 )
             }
         }
@@ -211,6 +213,10 @@ enum Commands {
         /// Automatically set to `walltime` on macro runners
         #[arg(short = 'm', long = "measurement-mode", env = "CODSPEED_RUNNER_MODE")]
         measurement_mode: Option<MeasurementMode>,
+
+        /// Arguments forwarded to each benchmark binary after `--`
+        #[arg(last = true)]
+        bench_args: Vec<String>,
     },
 }
 

--- a/crates/cargo-codspeed/src/run.rs
+++ b/crates/cargo-codspeed/src/run.rs
@@ -99,6 +99,7 @@ pub fn run_benches(
     package_filters: PackageFilters,
     bench_target_filters: BenchTargetFilters,
     measurement_mode: MeasurementMode,
+    bench_args: Vec<String>,
 ) -> Result<()> {
     let build_mode = measurement_mode.into();
     let codspeed_target_dir = get_codspeed_target_dir(metadata, build_mode);
@@ -132,6 +133,8 @@ pub fn run_benches(
         if let Some(bench_name_filter) = bench_name_filter.as_ref() {
             command.arg(bench_name_filter);
         }
+
+        command.args(&bench_args);
 
         command
             .status()

--- a/crates/cargo-codspeed/tests/simple-criterion.rs
+++ b/crates/cargo-codspeed/tests/simple-criterion.rs
@@ -123,6 +123,23 @@ fn test_criterion_build_and_run_filtered_by_name_single() {
 }
 
 #[test]
+fn test_criterion_walltime_run_forwards_args_after_double_dash() {
+    let dir = setup(DIR, Project::Simple);
+    cargo_codspeed(&dir)
+        .args(["build", "-m", "walltime"])
+        .assert()
+        .success();
+    cargo_codspeed(&dir)
+        .args(["run", "-m", "walltime", "--", "--exact", "fib 20"])
+        .assert()
+        .success()
+        .stdout(contains(FIB_BENCH_NAME))
+        .stdout(contains(BUBBLE_SORT_BENCH_NAME).not())
+        .stderr(contains("Finished running 2 benchmark suite(s)"));
+    teardown(dir);
+}
+
+#[test]
 fn test_criterion_cargo_bench_no_run() {
     let dir = setup(DIR, Project::Simple);
     std::process::Command::new("cargo")


### PR DESCRIPTION
## Summary
- `cargo codspeed run -- --exact <name>` failed with `unexpected argument '--exact' found` because the `Run` subcommand had no trailing-args field.
- Add a `bench_args` field with clap's `last = true` and forward those args to each bench command, mirroring `cargo bench` behavior.

Fixes COD-2646.

## Test plan
- [x] New test `test_criterion_walltime_run_forwards_args_after_double_dash` builds the criterion fixture in walltime mode and runs with `-- --exact "fib 20"`, asserting only `fib 20` appears in stdout while both suites still finish.
- [x] `cargo test --test simple-criterion` passes.