### PR TITLE
Fix lower bound of cc crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,19 @@ jobs:
       - name: Check divan_compat MSRV
         run: cargo msrv --path crates/divan_compat verify -- cargo check --all-features --config codspeed=true
 
+  minimal-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: moonrepo/setup-rust@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: rustup toolchain install nightly --profile minimal
+      - run: cargo +nightly update -Zminimal-versions -p codspeed --recursive
+      - run: cargo check -p codspeed --all-features --config codspeed=true
+
   tests-without-cargo-codspeed:
     runs-on: ubuntu-latest
     steps:
@@ -283,6 +296,7 @@ jobs:
       - tests-without-cargo-codspeed
       - test-cargo-codspeed
       - msrv-check
+      - minimal-versions
       - analysis-integration-test
       - walltime-integration-test
       - walltime-macos-test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,9 +493,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.38"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -895,9 +895,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.2"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "float-cmp"
@@ -1680,9 +1680,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"

--- a/crates/codspeed/Cargo.toml
+++ b/crates/codspeed/Cargo.toml
@@ -36,4 +36,4 @@ harness = false
 tempfile = { workspace = true }
 
 [build-dependencies]
-cc = "1.0"
+cc = "1.2.40"


### PR DESCRIPTION
Currently, the codspeed crate is declaring a dependency on cc 1.0, while using newer features. This is causing errors in minimal version checks in downstream crates.

This PR dumps the cc minimal version and adds a minimal-versions CI check to enforce correct lower bounds.