### PR TITLE
fix(divan): bump proc-macro-crate to parse multiline inline tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1100,9 +1100,9 @@ checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1444,11 +1444,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -1869,8 +1869,8 @@ checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.8",
+ "toml_edit 0.22.23",
 ]
 
 [[package]]
@@ -1883,6 +1883,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,8 +1900,29 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
- "winnow",
+ "toml_datetime 0.6.8",
+ "winnow 0.7.0",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2211,6 +2241,15 @@ name = "winnow"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]

--- a/crates/divan_compat/macros/Cargo.toml
+++ b/crates/divan_compat/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "codspeed-divan-compat-macros"
 version = "5.0.0"
-rust-version = "1.80"
+rust-version = "1.85"
 edition = "2021"
 description = "Macros for the Divan compatibility layer for CodSpeed"
 authors = ["Arthur Pastel <arthur@codspeed.io>"]
@@ -23,7 +23,7 @@ proc-macro = true
 [dependencies]
 divan-macros = { version = "=0.1.17" }
 itertools = { workspace = true }
-proc-macro-crate = "3.2.0"
+proc-macro-crate = "3.5.0"
 proc-macro2 = "1"
 quote = { version = "1", default-features = false }
 # Versions prior to *.18 fail to parse empty attribute metadata.


### PR DESCRIPTION
Bump `proc-macro-crate` from 3.2.0 to 3.5.0 in the divan compat macros crate so that the bench macro can parse consumer manifests that use multiline inline tables.

The `divan::bench` macro resolves the (often renamed) `codspeed-divan-compat` dependency by calling `proc_macro_crate::crate_name`, which parses the consumer's `Cargo.toml` with `toml_edit`. `proc-macro-crate` 3.2.0 pulled `toml_edit` 0.22, which parses in strict TOML 1.0 mode and rejects multiline inline tables — a TOML 1.1 feature that Cargo itself accepts. When a manifest contained one (e.g. a long `features = [...]` list wrapped across lines by a formatter), parsing failed, the rename could not be resolved, and the macro silently fell back to the unrenamed `codspeed_divan_compat` path, producing:

```
error[E0433]: cannot find `codspeed_divan_compat` in the crate root
```

`proc-macro-crate` 3.5.0 depends on `toml_edit` 0.25 (`+spec-1.1.0`), which parses multiline inline tables, so the rename resolves correctly.

This surfaced from a real user report (biome): after a CI formatter rewrapped a dependency in `biome_module_graph/Cargo.toml` into a multiline inline table, their divan benchmarks stopped compiling. Reproduced the exact `E0433` with `proc-macro-crate` 3.2.0 / `toml_edit` 0.22 against that manifest shape, and confirmed it compiles cleanly with 3.5.0 / `toml_edit` 0.25.

The crate's MSRV is raised 1.80 → 1.85 to match the rest of the workspace (`proc-macro-crate` 3.5.0 requires 1.82, and the parent `codspeed-divan-compat` lib is already 1.85, so this is not a consumer-facing bump). The CI `msrv-check` job for `divan_compat` passes at 1.85.

Closes COD-3022