### PR TITLE
ci: bump and pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
           cargo codspeed build -m ${{matrix.mode}} -p ${{ matrix.package }} ${{ matrix.features && format('--features {0}', matrix.features) || '' }}
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@main
+        uses: CodSpeedHQ/action@v5
         env:
           MY_ENV_VAR: "YES"
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,19 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
-      - uses: moonrepo/setup-rust@v1
+      - uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1.3.0
         with:
           components: rustfmt, clippy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: --all-files
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: bindgen-cli@0.72.1
       - name: Check if bindings are up-to-date
@@ -56,11 +56,11 @@ jobs:
           - { os: windows-latest, target: x86_64-pc-windows-msvc }
           - { os: windows-latest, target: aarch64-pc-windows-msvc }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
 
-      - uses: moonrepo/setup-rust@v1
+      - uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1.3.0
         with:
           targets: ${{ matrix.job.target }}
           # moonrepo/setup-rust does not allow for different cache keys per matrix job
@@ -71,11 +71,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Use this in place of the moonrepo/setup-rust cache, see above for explanation
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: ${{ matrix.job.target }}
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: cross@0.2.5
 
@@ -85,10 +85,10 @@ jobs:
   msrv-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
-      - uses: moonrepo/setup-rust@v1
+      - uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1.3.0
         with:
           bins: cargo-msrv
         env:
@@ -105,10 +105,10 @@ jobs:
   minimal-versions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
-      - uses: moonrepo/setup-rust@v1
+      - uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: rustup toolchain install nightly --profile minimal
@@ -118,10 +118,10 @@ jobs:
   tests-without-cargo-codspeed:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
-      - uses: moonrepo/setup-rust@v1
+      - uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1.3.0
         with:
           bins: cargo-nextest
         env:
@@ -134,10 +134,10 @@ jobs:
       matrix:
         partition: [1, 2, 3, 4, 5]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
-      - uses: moonrepo/setup-rust@v1
+      - uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1.3.0
         with:
           bins: cargo-nextest
         env:
@@ -161,10 +161,10 @@ jobs:
             features: async_futures
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
-      - uses: moonrepo/setup-rust@v1
+      - uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1.3.0
         with:
           cache-target: release
         env:
@@ -206,10 +206,10 @@ jobs:
           - package: codspeed-criterion-compat
             bench: criterion_integration_measurement_overhead
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
-      - uses: moonrepo/setup-rust@v1
+      - uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1.3.0
         with:
           cache-target: release
         env:
@@ -234,10 +234,10 @@ jobs:
   walltime-macos-test:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
-      - uses: moonrepo/setup-rust@v1
+      - uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1.3.0
         with:
           cache-target: release
         env:
@@ -273,10 +273,10 @@ jobs:
 
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
-      - uses: moonrepo/setup-rust@v1
+      - uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1.3.0
         with:
           targets: ${{ matrix.target }}
         env:
@@ -302,6 +302,6 @@ jobs:
       - walltime-macos-test
       - musl-build-check
     steps:
-      - uses: re-actors/alls-green@release/v1
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJson( needs ) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,11 @@ jobs:
 
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
           fetch-depth: 0
-      - uses: moonrepo/setup-rust@v1
+      - uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1.3.0
         with:
           targets: ${{ matrix.target }}
 
@@ -38,7 +38,7 @@ jobs:
       - run: cargo build --locked --release --bin cargo-codspeed --target ${{ matrix.target }}
 
       - name: Upload binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cargo-codspeed-${{ matrix.target }}
           path: ./target/${{ matrix.target }}/release/cargo-codspeed
@@ -48,11 +48,11 @@ jobs:
     needs: build-binaries
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
           fetch-depth: 0
-      - uses: moonrepo/setup-rust@v0
+      - uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1.3.0
         with:
           cache-target: release
           bins: cargo-workspaces
@@ -69,12 +69,12 @@ jobs:
         run: |
           NEW_VERSION=$(cargo workspaces ls --json | jq -r '.[] | select(.name == "codspeed") | .version')
           gh release create v$NEW_VERSION --title "v$NEW_VERSION" --generate-notes -d
-          echo "upload_url=$(gh release view v$NEW_VERSION --json uploadUrl | jq -r '.uploadUrl')" >> $GITHUB_OUTPUT
+          echo "tag=v$NEW_VERSION" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      tag: ${{ steps.create_release.outputs.tag }}
 
   upload-binaries:
     needs: publish
@@ -89,18 +89,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download binary artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cargo-codspeed-${{ matrix.target }}
           path: ./target/${{ matrix.target }}/release
 
       - name: Upload Release Asset
         if: github.event_name != 'workflow_dispatch'
-        uses: actions/upload-release-asset@v1
+        run: |
+          gh release upload "${{ needs.publish.outputs.tag }}" \
+            "./target/${{ matrix.target }}/release/cargo-codspeed#cargo-codspeed-${{ matrix.target }}" \
+            --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.publish.outputs.upload_url }}
-          asset_path: ./target/${{ matrix.target }}/release/cargo-codspeed
-          asset_name: cargo-codspeed-${{ matrix.target }}
-          asset_content_type: application/octet-stream
+          GH_REPO: ${{ github.repository }}

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,5 @@
+version: 3
+ignore_actions:
+  # Intentionally tracks the action's main branch to test unreleased changes.
+  - name: CodSpeedHQ/action
+    ref: main


### PR DESCRIPTION
Every `uses:` reference is now pinned to a full commit SHA with a version comment, managed by pinact (`.pinact.yaml`). This removes the mutable-tag supply-chain risk and clears the Node 20 deprecation warning, which came from `actions/checkout@v4`, not from CodSpeedHQ/action.

`CodSpeedHQ/action@main` is deliberately left unpinned so CI keeps exercising the action's unreleased changes; pinact ignores it.

Replace `actions/upload-release-asset@v1.0.2` with `gh release upload`: that action is archived and still targets Node 12, which current runners no longer execute. The release tag now flows from the `publish` job as a `tag` output instead of the `upload_url` output it replaces.